### PR TITLE
reusable workflows

### DIFF
--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -1,18 +1,34 @@
 name: 'terraform apply'
 
 on:
-  push:
-    tags:
-      - '*'
+  workflow_call:
+    inputs:
+      terraform_version:
+        description: 'The version of Terraform to use.'
+        type: string
+        default: '1.12.0'
+      working_directory:
+        description: 'The directory where Terraform commands will be executed.'
+        type: string
+        default: '.'
+      terraform_var_file:
+        description: 'The name of the Terraform variable file to use.'
+        type: string
+        default: 'terraform.auto.tfvars'
+      gcp_wif_provider:
+        description: 'GCP Workload Identity Federation Provider URI.'
+        type: string
+        required: true
+      gcp_wif_service_account:
+        description: 'GCP Service Account for WIF.'
+        type: string
+        required: true
+      gcp_terraform_state_bucket:
+        description: 'The GCS bucket name for Terraform state.'
+        type: string
+        required: true
 
 env:
-  TERRAFORM_STATE_FILE_BUCKET: ${{ secrets.TERRAFORM_STATE_FILE_BUCKET }}
-  WIF_PROVIDER: ${{ secrets.WIF_PROVIDER }} # Workload Identity Federation Provider
-  WIF_SERVICE_ACCOUNT: ${{ secrets.WIF_SERVICE_ACCOUNT }} # Deployment Service Account
-  
-  TERRAFORM_VERSION: '1.12.0'
-  TERRAFORM_VAR_FILE: 'terraform.auto.tfvars' # Terraform variable file to look for
-
   TF_LOG: INFO
   
 permissions:
@@ -32,24 +48,20 @@ jobs:
       - name: GCP Workload Identity Federation Connection
         uses: 'google-github-actions/auth@v2'
         with:
-          workload_identity_provider: ${{ env.WIF_PROVIDER }}
-          service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ inputs.gcp_wif_provider }}
+          service_account: ${{ inputs.gcp_wif_service_account }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: ${{ env.TERRAFORM_VERSION }}
+          terraform_version: ${{ inputs.terraform_version }}
 
       - name: Terraform Init
         id: init
-        # working-directory: ./environments/prod
+        working-directory: ${{ inputs.working_directory }}
         run: |
-          terraform init -backend-config="bucket=${{ env.TERRAFORM_STATE_FILE_BUCKET }}"
+          terraform init -backend-config="bucket=${{ inputs.gcp_terraform_state_bucket }}"
 
       - name: Terraform Apply
-        # working-directory: ./environments/prod
-        run: terraform apply -var-file=${{ env.TERRAFORM_VAR_FILE }} -auto-approve
-      
-
-
-      
+        working-directory: ${{ inputs.working_directory }}
+        run: terraform apply -var-file=${{ inputs.terraform_var_file }} -auto-approve

--- a/.github/workflows/example-usage-apply.yaml
+++ b/.github/workflows/example-usage-apply.yaml
@@ -1,0 +1,29 @@
+name: 'Example Reusable Terraform Apply Usage'
+
+on:
+  workflow_dispatch: # Allows manual triggering
+
+jobs:
+  terraform_apply_example:
+    name: 'Terraform Apply Example'
+    # IMPORTANT: Replace 'your-org/your-repo' with the actual path to this repository
+    # and '@main' with the desired ref (branch, tag, or commit SHA) where the reusable workflows exist.
+    # If this example is in the SAME repository as the reusable workflows,
+    # you can use './.github/workflows/apply.yaml@<ref>'
+    uses: ./.github/workflows/apply.yaml@feat/reusable-terraform-workflows # Adjust ref as needed, e.g., @main or @v1.0.0
+    with:
+      # Optional Inputs (examples show defaults or common usage):
+      # terraform_version: '1.12.0' # Default: '1.12.0'
+      # working_directory: '.'      # Default: '.' (current directory)
+      # terraform_var_file: 'terraform.auto.tfvars' # Default: 'terraform.auto.tfvars'
+
+      # Required Inputs (replace with your actual secret names if different):
+      gcp_wif_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+      gcp_wif_service_account: ${{ secrets.GCP_WIF_SERVICE_ACCOUNT }}
+      gcp_terraform_state_bucket: ${{ secrets.GCP_TERRAFORM_STATE_BUCKET }}
+    
+    secrets: inherit # Recommended for simplicity if secrets are defined at the repository or organization level.
+                     # Alternatively, pass them explicitly:
+      # GCP_WIF_PROVIDER: ${{ secrets.GCP_WIF_PROVIDER }}
+      # GCP_WIF_SERVICE_ACCOUNT: ${{ secrets.GCP_WIF_SERVICE_ACCOUNT }}
+      # GCP_TERRAFORM_STATE_BUCKET: ${{ secrets.GCP_TERRAFORM_STATE_BUCKET }}

--- a/.github/workflows/example-usage-plan.yaml
+++ b/.github/workflows/example-usage-plan.yaml
@@ -1,0 +1,29 @@
+name: 'Example Reusable Terraform Plan Usage'
+
+on:
+  workflow_dispatch: # Allows manual triggering
+
+jobs:
+  terraform_plan_example:
+    name: 'Terraform Plan Example'
+    # IMPORTANT: Replace 'your-org/your-repo' with the actual path to this repository
+    # and '@main' with the desired ref (branch, tag, or commit SHA) where the reusable workflows exist.
+    # If this example is in the SAME repository as the reusable workflows,
+    # you can use './.github/workflows/plan.yaml@<ref>'
+    uses: ./.github/workflows/plan.yaml@feat/reusable-terraform-workflows # Adjust ref as needed, e.g., @main or @v1.0.0
+    with:
+      # Optional Inputs (examples show defaults or common usage):
+      # terraform_version: '1.12.0' # Default: '1.12.0'
+      # working_directory: '.'      # Default: '.' (current directory)
+      # terraform_var_file: 'terraform.auto.tfvars' # Default: 'terraform.auto.tfvars'
+
+      # Required Inputs (replace with your actual secret names if different):
+      gcp_wif_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+      gcp_wif_service_account: ${{ secrets.GCP_WIF_SERVICE_ACCOUNT }}
+      gcp_terraform_state_bucket: ${{ secrets.GCP_TERRAFORM_STATE_BUCKET }}
+    
+    secrets: inherit # Recommended for simplicity if secrets are defined at the repository or organization level.
+                     # Alternatively, pass them explicitly:
+      # GCP_WIF_PROVIDER: ${{ secrets.GCP_WIF_PROVIDER }}
+      # GCP_WIF_SERVICE_ACCOUNT: ${{ secrets.GCP_WIF_SERVICE_ACCOUNT }}
+      # GCP_TERRAFORM_STATE_BUCKET: ${{ secrets.GCP_TERRAFORM_STATE_BUCKET }}

--- a/.github/workflows/plan.yaml
+++ b/.github/workflows/plan.yaml
@@ -1,18 +1,34 @@
 name: 'terraform plan'
 
 on:
-  push:
-    branches:
-      - main
+  workflow_call:
+    inputs:
+      terraform_version:
+        description: 'The version of Terraform to use.'
+        type: string
+        default: '1.12.0'
+      working_directory:
+        description: 'The directory where Terraform commands will be executed.'
+        type: string
+        default: '.'
+      terraform_var_file:
+        description: 'The name of the Terraform variable file to use.'
+        type: string
+        default: 'terraform.auto.tfvars'
+      gcp_wif_provider:
+        description: 'GCP Workload Identity Federation Provider URI.'
+        type: string
+        required: true
+      gcp_wif_service_account:
+        description: 'GCP Service Account for WIF.'
+        type: string
+        required: true
+      gcp_terraform_state_bucket:
+        description: 'The GCS bucket name for Terraform state.'
+        type: string
+        required: true
 
 env:
-  TERRAFORM_STATE_FILE_BUCKET: ${{ secrets.TERRAFORM_STATE_FILE_BUCKET }}
-  WIF_PROVIDER: ${{ secrets.WIF_PROVIDER }} # Workload Identity Federation Provider
-  WIF_SERVICE_ACCOUNT: ${{ secrets.WIF_SERVICE_ACCOUNT }} # Deployment Service Account
-  
-  TERRAFORM_VERSION: '1.12.0'
-  TERRAFORM_VAR_FILE: 'terraform.auto.tfvars' # Terraform variable file to look for
-
   TF_LOG: INFO
   
 permissions:
@@ -32,23 +48,23 @@ jobs:
       - name: GCP Workload Identity Federation Connection
         uses: 'google-github-actions/auth@v2'
         with:
-          workload_identity_provider: ${{ env.WIF_PROVIDER }}
-          service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ inputs.gcp_wif_provider }}
+          service_account: ${{ inputs.gcp_wif_service_account }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: ${{ env.TERRAFORM_VERSION }}
+          terraform_version: ${{ inputs.terraform_version }}
 
       - name: Terraform Init
         id: init
-        # working-directory: ./environments/prod
+        working-directory: ${{ inputs.working_directory }}
         run: |
-          terraform init -backend-config="bucket=${{ env.TERRAFORM_STATE_FILE_BUCKET }}"
+          terraform init -backend-config="bucket=${{ inputs.gcp_terraform_state_bucket }}"
 
       # Generates an execution plan for Terraform
       - name: Terraform Plan
         id: plan
-        # working-directory: ./environments/prod
+        working-directory: ${{ inputs.working_directory }}
         run: |
-          terraform plan -var-file=${{ env.TERRAFORM_VAR_FILE }} -out=tfplan
+          terraform plan -var-file=${{ inputs.terraform_var_file }} -out=tfplan


### PR DESCRIPTION
…or you.

I've split the single reusable workflow example into two separate files:
- `.github/workflows/example-usage-plan.yaml`
- `.github/workflows/example-usage-apply.yaml`

Here are the modifications I made to the examples and README documentation:
- Optional inputs within `with:` blocks are now commented out. This should help highlight their default values or that they are optional.
- Required inputs now directly use the `${{ secrets.SECRET_NAME }}` syntax, which I hope will make them easier for you to adopt.
- I've updated `README.md` to reflect these new example files and the changes in the YAML snippets.

Finally, I've removed the previous consolidated `example-usage.yaml` file.